### PR TITLE
implement feedback from WS3 & ESA (doc hierarchy v2)

### DIFF
--- a/pages/group-1/index.md
+++ b/pages/group-1/index.md
@@ -2,8 +2,8 @@
 
 The "Getting Started" page is your essential guide to navigating EarthCODE. Whether you're new to the platform or looking to deepen your involvement, this page will introduce you to the key concepts, features, and community of EarthCODE. You’ll find a step-by-step guide to help you understand EarthCODE terminology, explore its tools and capabilities, and learn how to engage with the community. By following these steps, you’ll be well-equipped to start using EarthCODE effectively, contribute to ongoing projects, and collaborate with other researchers.
 
-- [Introduction to EarthCODE](./page-1)
-- [Accessing EarthCode](./page-2)
-- [Connecting to External Platforms and Services](./page-3)
+- [10 minutes to EarthCODE](./page-1)
+- [Deep Dive into EarthCode](./page-2)
+- [Connecting External Platforms to EarthCODE](./page-3)
 - [Collaboration and Community](./page-4)
 - [Troubleshooting and Support](./page-5)

--- a/pages/group-1/page-1.md
+++ b/pages/group-1/page-1.md
@@ -1,11 +1,3 @@
-# Introduction to EarthCODE
+#  10 minutes to EarthCODE
 
-## Overview of EarthCODE
-A brief introduction to the EarthCODE platform, its purpose, and the core features it offers to researchers in Earth System Science.
-
-## Key Components
-A high-level description of the platform’s main components: the Portal, Open Science Catalogue, FAIR tools, scalable computing resources, and community services.
-
-## How EarthCODE Supports FAIR and Open Science
-A summary of how the platform adheres to FAIR principles and supports reproducible, open, and collaborative science.
-
+TBD

--- a/pages/group-1/page-2.md
+++ b/pages/group-1/page-2.md
@@ -1,11 +1,11 @@
-# Accessing EarthCODE
+# Deep Dive into EarthCODE
 
-## Creating an Account
-Step-by-step instructions for creating an EarthCODE user account.
+## Overview of EarthCODE
+A brief introduction to the EarthCODE platform, its purpose, and the core features it offers to researchers in Earth System Science.
 
-## Logging In
-Instructions on how to log in to the EarthCODE Portal and manage your user profile.
+## Key Components
+A high-level description of the platform’s main components: the Portal, Open Science Catalogue, FAIR tools, scalable computing resources, and community services.
 
-## Navigating the Portal
-An overview of the user interface and how to access key features like data discovery, tool access, and community forums.
+## How EarthCODE Supports FAIR and Open Science
+A summary of how the platform adheres to FAIR principles and supports reproducible, open, and collaborative science.
 

--- a/pages/group-1/page-3.md
+++ b/pages/group-1/page-3.md
@@ -1,5 +1,11 @@
-# Connecting to External Platforms and Services
-Guidance on how to integrate EarthCODE with external cloud computing services and other relevant platforms.
+# Accessing EarthCODE
 
-## Creating and Managing Projects
-How to create a new research project, add team members, and organize project resources (data, workflows, documentation).
+## Creating an Account
+Step-by-step instructions for creating an EarthCODE user account.
+
+## Logging In
+Instructions on how to log in to the EarthCODE Portal and manage your user profile.
+
+## Navigating the Portal
+An overview of the user interface and how to access key features like data discovery, tool access, and community forums.
+

--- a/pages/group-1/page-4.md
+++ b/pages/group-1/page-4.md
@@ -1,10 +1,6 @@
-# Collaboration and Community
-## Joining or Creating a Research Team
-How to collaborate with other researchers by joining existing teams or creating new ones.
+# Connecting External Platforms to EarthCODE
 
-## Using Community Resources
-How to access guides, tutorials, forums, and other community resources to support research activities.
+Guidance on how to integrate external cloud computing services and other relevant platforms to EarthCODE.
 
-## Sharing and Publishing Results
-Instructions on how to share research outputs, including data, code, and documentation, and manage their publication through the Open Science Catalogue.
-
+## Creating and Managing Projects
+How to create a new research project, add team members, and organize project resources (data, workflows, documentation).

--- a/pages/group-1/page-5.md
+++ b/pages/group-1/page-5.md
@@ -1,10 +1,10 @@
-# Troubleshooting and Support
+# Collaboration and Community
+## Joining or Creating a Research Team
+How to collaborate with other researchers by joining existing teams or creating new ones.
 
-This sub-section provides solutions to common issues that users may encounter while configuring tools and platforms.
+## Using Community Resources
+How to access guides, tutorials, forums, and other community resources to support research activities.
 
-## Common Issues and Solutions
-A list of common problems users might encounter and how to resolve them.
-
-## Getting Help
-Information on how to contact support, access user forums, or refer to the documentation for more help.
+## Sharing and Publishing Results
+Instructions on how to share research outputs, including data, code, and documentation, and manage their publication through the Open Science Catalogue.
 

--- a/pages/group-1/page-6.md
+++ b/pages/group-1/page-6.md
@@ -1,0 +1,10 @@
+# Troubleshooting and Support
+
+This sub-section provides solutions to common issues that users may encounter while configuring tools and platforms.
+
+## Common Issues and Solutions
+A list of common problems users might encounter and how to resolve them.
+
+## Getting Help
+Information on how to contact support, access user forums, or refer to the documentation for more help.
+

--- a/pages/group-2/index.md
+++ b/pages/group-2/index.md
@@ -1,8 +1,9 @@
-# Setting Up Your Research Environment
+# Technical Documentation 
 
-The "Setting Up Your Research Environment" page provides detailed guidance on how to configure and personalize your EarthCODE environment for your specific research needs. Here, you will find instructions on accessing and integrating the tools, data, and services required for your projects. From setting up your workspace to connecting to cloud platforms and ensuring access to the Open Science Catalogue, this page will help you get everything in place for efficient and effective research. It also covers best practices for managing your data, code, and workflows, ensuring you have a seamless, collaborative research environment.
+The "Technical Documentation" page provides detailed guidance on how to configure and personalize your EarthCODE environment for your specific research needs. Here, you will find instructions on accessing and integrating the tools, data, and services required for your projects. From setting up your workspace to connecting to cloud platforms and ensuring access to the Open Science Catalogue, this page will help you get everything in place for efficient and effective research. It also covers best practices for managing your data, code, and workflows, ensuring you have a seamless, collaborative research environment.
 
-- [Choosing and Configuring Tools](./page-1)
-- [Working with Data](./page-2)
-- [Developing and Executing Workflows](./page-3)
-- [Managing Your Research Outputs](./page-4)
+- [Choosing Tools and platforms](./page-1)
+- [Platforms](./page-2)
+- [Publishing to EarthCODE](./page-3)
+- [Working with Data](./page-4)
+- [Working with Workflows](./page-5)

--- a/pages/group-2/page-1.md
+++ b/pages/group-2/page-1.md
@@ -1,4 +1,4 @@
-# Choosing and Configuring Tools and Platforms
+# Choosing Tools and Platforms
 
 This section guides users through the process of selecting, configuring, and integrating the tools and platforms available within EarthCODE for their research needs. It helps users make informed choices based on their project's requirements, whether they are working with cloud computing, data analysis, or machine learning.
 
@@ -29,43 +29,4 @@ Step-by-step recommendations for matching project types (e.g., small-scale analy
 ### Key Considerations
 
 Factors to consider when selecting platforms, such as cost, scalability, compatibility with existing workflows, and integration with EarthCODE’s services.
-
-## Configuring Tools and Platforms for Your Workflow
-
-Once the appropriate platform is chosen, this sub-section provides practical steps to configure and integrate the selected tools into the user’s research environment.
-
-### Connecting to Cloud Platforms
-
-Instructions for connecting to cloud services (e.g., AWS, Azure, Google Cloud), setting up virtual environments, and configuring storage.
-
-### Integration with EarthCODE Services
-
-Step-by-step guidance for linking selected platforms with EarthCODE’s Open Science Catalogue, FAIR tools, and collaborative features.
-
-### Data Access and Configuration
-
-Setting up data access points, retrieving datasets from external platforms, and configuring pipelines to process and analyze data.
-
-## Using the Development Tools
-
-This sub-section focuses on using the integrated development tools within EarthCODE. It includes:
-
-### Version Control (e.g., GitHub integration)
-
-Instructions on how to manage project versions, track changes, and collaborate with other researchers.
-
-### Workflow Management
-
-Guidance on using EarthCODE's workflow tools, such as interactive notebooks, containers, and pipeline orchestration for reproducible research.
-
-### Automation and Continuous Integration
-
-Setting up automated processes for testing, deployment, and data processing using continuous integration/continuous deployment (CI/CD) pipelines.
-
-## Best Practices for Configuration and Collaboration
-This sub-section offers practical advice for configuring tools and platforms to ensure smooth collaboration and adherence to best practices.
-
-### Optimizing Performance
-
-Tips on configuring resources to achieve optimal performance for large datasets and computational tasks.
 

--- a/pages/group-2/page-2.md
+++ b/pages/group-2/page-2.md
@@ -1,10 +1,41 @@
-# Working with Data
-## Data Discovery and Access
-Instructions on how to search and access data through the Open Science Catalogue, including metadata and dependencies.
+# Platforms
 
-## Uploading and Managing Your Data
-How to upload data to EarthCODE, manage storage, and apply version control to datasets.
+All EarthCODE platforms are listed by alphabetical order.
+We will mostly link to external documentation but to offer a consistent user experience, we will have the same sub-sections for each platform.
 
-## Using Data in Workflows
-How to incorporate data into your workflows and experiments within EarthCODE.
+## Copernicus Data Space Ecosystem (CDSE)
 
+- Configuring CDSE for Your Workflow
+- Connecting to CDSE: https://dataspace.copernicus.eu
+- Integration CDSE with EarthCODE Open Science Catalogue
+- Data Access on CDSE
+
+## Deep Earth System Data Laboratory (DeepESDL)
+
+
+- Configuring DeepESDL for Your Workflow
+- Connecting to DeepESDL: https://deep.earthsystemdatalab.net/
+- Integration DeepESDL with EarthCODE Open Science Catalogue
+- Data Access on DeepESDL
+
+
+## Euro Data Cube 
+
+- Configuring Euro Data Cube for Your Workflow
+- Connecting to Euro Data Cube: https://eurodatacube.com
+- Integration Euro Data Cube with EarthCODE Open Science Catalogue
+- Data Access on Euro Data Cube
+
+## EoxHub/Colcalc  
+
+- Configuring EoxHub/Colcalc for Your Workflow
+- Connecting to EoxHub/Colcalc: TBD
+- Integration EoxHub/Colcalc with EarthCODE Open Science Catalogue
+- Data Access on EoxHub/Colcalc
+
+## EoxHub/Pangeo
+
+- Configuring EoxHub/Pangeo for Your Workflow
+- Connecting to EoxHub/Pangeo: TBD
+- Integration EoxHub/Pangeo with EarthCODE Open Science Catalogue
+- Data Access on EoxHub/Pangeo

--- a/pages/group-2/page-3.md
+++ b/pages/group-2/page-3.md
@@ -1,11 +1,23 @@
-# Developing and Executing Workflows
+# Publishing to EarthCODE
 
-## Creating Workflows
-How to develop research workflows using EarthCODE’s interactive graphical tooling, including workflow design and validation.
+This sub-section focuses on using the integrated development tools within EarthCODE. It includes:
 
-## Running Workflows
-How to execute workflows using the platform’s cloud-based resources, including how to monitor progress and manage execution.
+## Version Control (e.g., GitHub integration)
 
-## Using Machine Learning Tools
-Instructions on setting up and running machine learning models within EarthCODE’s scalable environment.
+Instructions on how to manage project versions, track changes, and collaborate with other researchers.
+
+## Workflow Management
+
+Guidance on using EarthCODE's workflow tools, such as interactive notebooks, containers, and pipeline orchestration for reproducible research.
+
+## Automation and Continuous Integration
+
+Setting up automated processes for testing, deployment, and data processing using continuous integration/continuous deployment (CI/CD) pipelines.
+
+## Best Practices for Configuration and Collaboration
+This sub-section offers practical advice for configuring tools and platforms to ensure smooth collaboration and adherence to best practices.
+
+## Optimizing Performance
+
+Tips on configuring resources to achieve optimal performance for large datasets and computational tasks.
 

--- a/pages/group-2/page-4.md
+++ b/pages/group-2/page-4.md
@@ -1,11 +1,10 @@
-# Managing Your Research Outputs
+# Working with Data
+## Data Discovery and Access
+Instructions on how to search and access data through the Open Science Catalogue, including metadata and dependencies.
 
-## Version Control for Data and Code
-How to use version control systems (such as GitHub) for managing the different versions of your research outputs.
+## Uploading and Managing Your Data
+How to upload data to EarthCODE, manage storage, and apply version control to datasets.
 
-## Publishing to the Open Science Catalogue
-Detailed instructions on how to publish final research outputs to the Open Science Catalogue, including citation and DOI management.
-
-## Long-Term Storage and Access
-How to ensure the long-term preservation of your research outputs using EarthCODE’s storage services.
+## Using Data in Workflows
+How to incorporate data into your workflows and experiments within EarthCODE.
 

--- a/pages/group-2/page-5.md
+++ b/pages/group-2/page-5.md
@@ -1,0 +1,11 @@
+# Working with Workflows
+
+## Creating Workflows
+How to develop research workflows using EarthCODE’s interactive graphical tooling, including workflow design and validation.
+
+## Running Workflows
+How to execute workflows using the platform’s cloud-based resources, including how to monitor progress and manage execution.
+
+## Using Machine Learning Tools
+Instructions on setting up and running machine learning models within EarthCODE’s scalable environment.
+

--- a/pages/group-3/index.md
+++ b/pages/group-3/index.md
@@ -1,0 +1,8 @@
+# Training and Resources
+
+In the "Training and Resources" section, users will find everything they need to deepen their understanding and make the most of EarthCODE. This includes step-by-step tutorials, engaging video guides, a gallery of interactive Jupyter notebooks showcasing real-world use cases, and information about upcoming training events and webinars. Whether you're new to EarthCODE or looking to refine your skills, this section provides practical tools and learning opportunities to help you master the platform and advance your research.
+
+- [Tutorials](./page-1)
+- [Videos and Webinars](./page-2)
+- [Gallery](./page-3)
+- [Events and Workshops](./page-4)

--- a/pages/group-3/page-1.md
+++ b/pages/group-3/page-1.md
@@ -1,0 +1,17 @@
+# Tutorials and Learning Pathways
+
+In this section, we group tutorials into different learning pathways to help you progressively build the skills needed to master EarthCODE. Whether you're just starting or aiming to become an expert, each pathway is designed to guide you through key concepts and features of EarthCODE. You’ll gain practical, hands-on experience as you move from basic to advanced topics, ensuring that you can apply your learning effectively in real-world research projects.
+
+## Start Simple
+For those new to EarthCODE, this pathway covers the basics to get you up and running quickly. Learn the fundamental features, how to set up your environment, and perform simple tasks that are essential for beginning your EarthCODE journey.
+
+- [Cubes & Clouds](https://eo-college.org/courses/cubes-and-clouds/): This course teaches the concepts of data cubes, cloud platforms, and open science in the context of earth observation.  
+
+## Grow Your Skills
+
+Once you're familiar with the basics, this pathway takes you deeper into EarthCODE. Explore more advanced functionalities, such as configuring workflows, working with data, and collaborating with other researchers. You’ll gain practical experience in applying EarthCODE’s tools to enhance your research projects.
+
+## Excel with EarthCODE
+
+This pathway is for advanced users looking to maximize the potential of EarthCODE. Learn best practices for optimizing workflows, managing large datasets, and contributing to the EarthCODE community. You'll also explore expert-level features to take your research to the next level, fostering innovation and collaboration.
+

--- a/pages/group-3/page-2.md
+++ b/pages/group-3/page-2.md
@@ -1,0 +1,3 @@
+# Videos and Webinars
+
+A collection of training videos and recorded sessions.

--- a/pages/group-3/page-3.md
+++ b/pages/group-3/page-3.md
@@ -1,0 +1,2 @@
+# Gallery
+Highlighting user contributions, including notable projects and examples.

--- a/pages/group-3/page-4.md
+++ b/pages/group-3/page-4.md
@@ -1,0 +1,4 @@
+# Events and Workshops
+Information on upcoming training events and access to recordings of past sessions.
+
+

--- a/pages/group-4/index.md
+++ b/pages/group-4/index.md
@@ -1,0 +1,4 @@
+# Best practices
+
+- [FAIR and Open Science](./page-1)
+- [Code, Data and Workflow Quality](./page-2)

--- a/pages/group-4/page-1.md
+++ b/pages/group-4/page-1.md
@@ -1,0 +1,9 @@
+# FAIR and Open Science
+
+## From FAIR principles to FAIR in practice
+
+## Open Science
+
+## Collaboration Tips
+
+Guidance for setting up user permissions, managing team workflows, and collaborating with other researchers within the EarthCODE environment.

--- a/pages/group-4/page-2.md
+++ b/pages/group-4/page-2.md
@@ -1,0 +1,12 @@
+# Code, Data and Workflow Quality
+
+## Applying and maintaining FAIR Principles
+Guidelines on how to implement FAIR principles within your research workflow, data management, and publication process.
+
+Ensuring all research outputs, including code, data, and documentation, are compliant with FAIR (Findable, Accessible, Interoperable, and Reusable) principles.
+
+## Best Practices for high-quality Code, Data and Workflows
+
+Tips and guidelines for maintaining high-quality code and data, including automated testing and validation.
+
+

--- a/pages/index.md
+++ b/pages/index.md
@@ -12,7 +12,7 @@ hero:
       link: /page-1
     - theme: alt
       text: Community and Best Practices
-      link: /page-2
+      link: /group-4/
 
 features:
   - title: Integrated Open Science Environment

--- a/pages/page-2.md
+++ b/pages/page-2.md
@@ -1,14 +1,41 @@
-# Best Practices
+# Key terms and concepts
 
-## Applying and maintaining FAIR Principles
-Guidelines on how to implement FAIR principles within your research workflow, data management, and publication process.
+## Acronyms, Abbreviations, and Terms
 
-Ensuring all research outputs, including code, data, and documentation, are compliant with FAIR (Findable, Accessible, Interoperable, and Reusable) principles.
+| **Term**                      | **Meaning**                                                                                                                                                          |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **DOI**                        | Digital Object Identifier                                                                                                                                             |
+| **FAIR**                       | Findable, Accessible, Interoperable, and Reusable                                                                                                                     |
+| **Nor**                        | Network of Resources                                                                                                                                                  |
+| **OGC**                        | Open Geospatial Consortium                                                                                                                                            |
+| **Config Metadata**            | Metadata describing the configuration of a workflow, used to formally describe the configuration needed by a reproducible experiment.                                 |
+| **Dashboard**                  | A web application that visualizes Earth Observation data and service insights, serving as a human interface to a workflow.                                            |
+| **Dashboard Metadata**         | Metadata describing a dashboard.                                                                                                                                      |
+| **Experiment (Scientific Experiment)** | A collection of technical artifacts that describe an experiment and how to reproduce it. This typically involves workflows implemented with code (e.g., Python, R). |
+| **Experiment Metadata**        | Metadata describing an experiment, potentially referencing Workflow Metadata, Input Data Metadata, and Config Metadata.                                               |
+| **Input Data**                 | A formal definition of data referenced using a unique ID, describing the data needed by a reproducible experiment.                                                   |
+| **Input Data Metadata**        | Metadata describing input data for an experiment/workflow.                                                                                                           |
+| **Product**                    | The output of a scientific experiment using a specific workflow implementation.                                                                                     |
+| **Product Metadata**           | Metadata describing a product.                                                                                                                                       |
+| **Workflow**                   | A formal wrapper for scientific code that can run in a specific container or environment on the cloud, often developed in languages like Python, R, or machine learning. |
+| **Workflow Metadata**          | Metadata describing a workflow, including required input parameters and acceptable values.                                                                           |
 
-## Code and Data Quality Best Practices
-Tips and guidelines for maintaining high-quality code and data, including automated testing and validation.
+## Key Concepts
 
-## Collaboration Tips
+| **Term**                            | **Meaning**                                                                                                                                                          |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Earth Collaborative Open Development Environment (EarthCODE)** | A collaborative platform for developing scientific Earth Observation research projects in an open, FAIR-compliant environment.                                      |
+| **EarthCODE Portal**                | A web interface for users to interact with the EarthCODE platform, focusing on accessibility and collaboration in research projects.                                    |
+| **Open Science Catalogue**          | A platform for discovering and sharing scientific outputs, aligned with open science principles.                                                                     |
+| **Infrastructure Platform Services**| Cloud-based tools and technologies that support the execution of scientific workflows in an open, FAIR-compliant environment.                                         |
+| **Community Platform Services**     | Tools that facilitate collaboration among scientists, encouraging the exchange and development of research materials.                                                  |
+| **Development Tooling for FAIR Open Science** | Tools for managing the development of FAIR-compliant research materials, ensuring accessibility, reproducibility, and interoperability.                              |
+| **Platform Service Onboarding**     | The process of integrating external services and tools into the EarthCODE platform to extend its capabilities.                                                         |
+| **Long-term Preservation Services**  | Tools and practices designed to ensure the longevity and accessibility of scientific data and outputs over time.                                                       |
+| **Interactive Dashboards**          | Visual tools that allow researchers to explore and interact with data, research results, and insights in real time.                                                     |
+| **Cloud Optimized Data Retrieval**  | Techniques for efficiently accessing and retrieving data from cloud storage environments, particularly for large datasets in scientific workflows.                      |
+| **Version Management for Resources**| Systems for tracking and managing different versions of scientific resources (code, data, etc.), ensuring reproducibility and consistency.                            |
+| **Community Engagement Tools**      | Tools designed to facilitate interaction and collaboration within the scientific community, enabling the sharing of knowledge and resources.                          |
+| **Collaboration and Sharing Tools** | Tools that promote collaboration among researchers, including shared workspaces, communication tools, and version-controlled resources.                                |
 
-Guidance for setting up user permissions, managing team workflows, and collaborating with other researchers within the EarthCODE environment.
 


### PR DESCRIPTION
- Added list of key terms and concepts 
- Added a page "10 minutes to earthcode" but we still need to write the content (will come with another PR)
- Added a separated page for EarthCODE platforms 
- Added a section for Tutorials with the following sections: 1) Tutorials and Learning Pathways (where we will (in another PR) also list the required skills and what training users can follow to master them), 2) Videos and Webinars, 3) Gallery, 4) Events and Workshops
- Changed Connecting External Platforms and Services to Connecting External Platforms to EarthCODE (I.e. I can publish stuff from my platform to EarthCODE)
- Renamed Setting up your research environment to Technical Documentation
- Push Configuring Tools and Platforms for your workflow and others to the platform specific page
- Renamed "Using the Development Tools"  to -Publishing to EarthCODE 
- Renamed "Developing and Executing workflows"  to  "Working with workflows" 
- Created a separate section for Best practices with the following pages: 1) FAIR and Open-Science, 2) Code, Data and workflow Quality