### PR TITLE
fix section titles in index

### DIFF
--- a/pages/Community and Best Practices/index.md
+++ b/pages/Community and Best Practices/index.md
@@ -1,4 +1,4 @@
 # Best practices
 
-- [FAIR and Open Science](./Code%20Data%20and%20Workflow%20Quality.md)
-- [Code, Data and Workflow Quality](./FAIR%20and%20Open%20Science.md)
+- [FAIR and Open Science](./FAIR%20and%20Open%20Science.md)
+- [Code, Data and Workflow Quality](./Code%20Data%20and%20Workflow%20Quality.md)


### PR DESCRIPTION
    For some reasons, there were switched between FAIR and Open Science with Quality, etc.