### PR TITLE
Hotfix: add appropriate external url to sidebar link

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -109,7 +109,7 @@ const sideBar = withSidebar(
 )
 
 const trainingSection = sideBar.themeConfig.sidebar.find(section => section.text === 'Training and Resources')
-trainingSection.items.push({ text: 'Examples', link: 'https://earthcode.esa.int/examples' })
+trainingSection.items.push({ text: 'Examples', link: 'https://esa-earthcode.github.io/documentation/examples/' })
 
 export default defineConfig(
   sideBar


### PR DESCRIPTION
Fixed the link to the external examples.

However, the other links (in the text) seem buggy! See #36



